### PR TITLE
Separating framework from editor

### DIFF
--- a/mgk-edit.code-workspace
+++ b/mgk-edit.code-workspace
@@ -2,9 +2,6 @@
 	"folders": [
 		{
 			"path": "."
-		},
-		{
-			"path": "../MGKFrameworkJS"
 		}
 	],
 	"settings": {}


### PR DESCRIPTION
# Changes:

> I removed the workspace reference to MGKFrameworkJS in the workspace for MGKEdit.
> This will prompt me to compartmentalize and enable the possibility to apply more than one framework.